### PR TITLE
Keep your back, forward,reload buttons

### DIFF
--- a/downsizewindow.css
+++ b/downsizewindow.css
@@ -1,0 +1,81 @@
+
+/* the following will hide any nav bar item you have listed.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
+
+toolbarbutton:is(
+
+[id="back-button"],[id="forward-button"],[id="reload-button"]
+
+/*extension menu-> ,[id="unified-extensions-button"],  */
+/*ublock        -> [data-extensionid="uBlock0@raymondhill.net"],  */
+/*getanID       -> [id=""], */
+/*getanID       -> [id=""]  */
+
+)
+
+{display: none !important;}
+
+/*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+the following will temporarily take nav bar items 
+off the the screen when browser size = little over half of a 1080p
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
+
+@media (max-width:890px) {
+toolbarbutton:is(
+
+[id="_b9db16a4-6edc-47ec-a1f4-b86292ed211d_-BAP"],
+[id="unified-extensions-button"]
+
+/* <- remove if you want to make a button list
+,[data-extensionid="uBlock0@raymondhill.net"],
+[id=""],
+[id=""]
+remove if you want to make a button list -> */
+
+),
+
+/*Hide bookmarks except for the following, get your bookmark names*/
+
+toolbarbutton[class="bookmark-item"]:not([label="📺"], [label="⚙️"], [label="🌐"], [label="📧"])
+
+{display: none !important;}
+} /*<--- close out sizing attribute */
+/*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+portrait territory
+
+@media (max-width:600px) { 
+}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
+
+
+overflows="true"
+removable="true"
+
+
+
+/* the overflow button likes to try and override buttons
+when resizing of windows is done. gonna try to fix that.
+*/
+toolbar:is([overflowing]) > .overflow-button
+{display: none !important;}  
+toolbar:is([overflowing]) > .overflow-button
+{overflows:true !important; removable: true !important;}
+
+/*choose which buttons will always stay*/
+toolbar:is([id="minmaxclose_soulhotel_net-BAP"]),
+toolbar:is([data-extensionid="browserhub@soulhotel.net"])
+{
+appearance: none !important;
+-moz-window-dragging: no-drag !important;
+box-sizing: border-box !important;
+align-items: center !important;
+display: flex !important;
+flex: 1 !important;
+overflows: visible !important;
+overflows: false !important;
+overflow: visible !important;
+removable: false !important;}
+
+


### PR DESCRIPTION
this theme removes the back,forward,reload buttons from nav bar.

REMEMBER they are also in the context menu and have keyboard shortcuts. But If you just want to keep them, replace /chrome/CSS/downloadsizewindow.css with this file.